### PR TITLE
make npm serve listen on localhost only (for prod deployment with webserver in front)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "index.mjs",
     "scripts": {
-        "serve": "npx http-server"
+        "serve": "npx http-server -a localhost -p 3001"
     },
     "dependencies": {
         "ethers": "6.5.1"


### PR DESCRIPTION
@soundyogi I hope this is fine for your local dev env as well. You can connect on http://localhost:3001